### PR TITLE
fix package on 1.5

### DIFF
--- a/src/ChrBase.jl
+++ b/src/ChrBase.jl
@@ -33,8 +33,8 @@ include("CaseTables.jl"); using .CaseTables
 include("casefold.jl")
 include("io.jl")
 include("traits.jl")
-include("unicode.jl")
 include("utf8proc.jl")
+include("unicode.jl")
 
 @api freeze
 


### PR DESCRIPTION
This package overwrites a base function in unicode.jl (`category_code`) and makes that call into a function that is only defined later in `utf8proc.jl`. Solve this by changing the order so the function is already defined when the type piracy happens.